### PR TITLE
Simplify checks for warnings and errors

### DIFF
--- a/tests/testthat/test_underconstrained_positions.R
+++ b/tests/testthat/test_underconstrained_positions.R
@@ -9,47 +9,36 @@ titertable <- read.titerTable("../testdata/titer_tables/titer_table5_underconstr
 map <- acmap(titer_table = titertable)
 
 test_that("Warn of undercontrained positions", {
-  res <- evaluate_promise(
+  expect_warning(
     optimizeMap(
       map = map,
       number_of_dimensions = 2,
       number_of_optimizations = 1,
       minimum_column_basis = "none",
-    )
-  )
-
-  expect_warning(
-    res$warnings,
+    ),
     "Some points are undercontrained for the given dimension"
   )
 })
 
 test_that("Optimize points if underconstrained but have finite positions", {
-  res <- evaluate_promise(
-    optimizeMap(
-      map = map,
-      number_of_dimensions = 2,
-      number_of_optimizations = 1,
-      minimum_column_basis = "none",
-    )
+  res <- optimizeMap(
+    map = map,
+    number_of_dimensions = 2,
+    number_of_optimizations = 1,
+    minimum_column_basis = "none",
   )
-  expect_false(anyNA(agBaseCoords(res$result, 1)))
+  expect_false(anyNA(agBaseCoords(res, 1)))
 })
 
 test_that("Error for undercontrained points with infinite positions", {
   titerTable(map)[4, 2] <- "*"
-
-  res <- evaluate_promise(
+  expect_error(
     optimizeMap(
       map = map,
       number_of_dimensions = 2,
       number_of_optimizations = 1,
       minimum_column_basis = "none",
-    )
-  )
-
-  expect_error(
-    res$output,
+    ),
     "Some points are undercontrained for the given dimension"
   )
 })


### PR DESCRIPTION
Mostly for myself to go through the process of trying to suggest edits to someone else's pull request I've suggested some changes here to simplify things, although the `evaluate_promise` function is a neat one that I wasn't aware of it feels unnecessary here.  I also didn't know about the function `anyNA`, great stuff!